### PR TITLE
PlayButton Atom and changes to video embeds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emailjs/browser": "^3.11.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
+        "@mui/icons-material": "^5.15.3",
         "@mui/material": "^5.15.3",
         "@mui/styled-engine-sc": "^6.0.0-alpha.11",
         "@testing-library/jest-dom": "^5.17.0",
@@ -3476,6 +3477,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.3.tgz",
+      "integrity": "sha512-7LEs8AnO2Se/XYH+CcJndRsGAE+M8KAExiiQHf0V11poqmPVGcbbY82Ry2IUYf9+rOilCVnWI18ErghZ625BPQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.6"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@emailjs/browser": "^3.11.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.3",
     "@mui/material": "^5.15.3",
     "@mui/styled-engine-sc": "^6.0.0-alpha.11",
     "@testing-library/jest-dom": "^5.17.0",

--- a/src/components/atoms/buttons/PlayButton.tsx
+++ b/src/components/atoms/buttons/PlayButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from '@mui/system/styled';
+import PlayArrowIcon from "@mui/icons-material/PlayArrow";
+
+// TODO 
+// Figure out how to get the size of the icon to increase
+// Figured out everything but the size
+const CustomPlayButton = styled("div")({
+  position: "absolute",
+  top: "45%", 
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  color: "white",
+  paddingBottom: "50px"
+});
+
+// Discovered StyledComponent stylings can also be  
+// written in a more classic CSS style syntax:
+// const CustomPlayButton = styled.button`
+//   background: transparent;
+//   position: absolute;
+//   top: 45%;
+//   left: 50%;
+//   transform: translate(-50%, -50%);
+//   color: white;
+//   font-size: 100px;
+//   border: none;
+//   padding-bottom: 100px;
+// `
+
+export function PlayButton() {
+  return (
+    <CustomPlayButton >
+      <PlayArrowIcon />
+    </CustomPlayButton>
+  );
+}

--- a/src/components/atoms/video/Video.tsx
+++ b/src/components/atoms/video/Video.tsx
@@ -1,10 +1,18 @@
 import { CardMedia } from "@mui/material";
-
-type VideoProps = {
+import { PlayButton } from "../buttons/PlayButton";
+interface VideoProps {
   url: string;
-};
-
-// WIP
-export function Video({ url }: VideoProps) {
-  return <CardMedia src={url} component={"iframe"} />;
 }
+
+export function Video({ url }: VideoProps) {
+
+  return (
+    <CardMedia>
+      <iframe src={`${url}?controls=0`} title="Video" />
+
+      {PlayButton()}
+    </CardMedia>
+  );
+}
+
+


### PR DESCRIPTION
Figured out how to make a Play Button as just an icon on the embedded videos. No functionality yet though. 
This also removed any other "YouTube" links that appear on embedded videos. 

<img width="353" alt="Screen Shot 2024-01-08 at 10 43 03 PM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/a94ad8ed-92df-4cfe-b29d-48c856a4abae">
