### PR TITLE
Update video card to only show 'other' tags

### DIFF
--- a/src/common/constants/constants.ts
+++ b/src/common/constants/constants.ts
@@ -1,5 +1,7 @@
 import { Genre, Role } from './enums'
 
+export type PageEnum = Genre | Role
+
 export const roleToText: { [key in Role]: string } = {
   camera_operator: 'Camera Operator',
   director_producer: 'Director & Producer',

--- a/src/common/utils/utils.ts
+++ b/src/common/utils/utils.ts
@@ -1,4 +1,5 @@
 import {
+  PageEnum,
   genreToText,
   genreToUrl,
   roleToText,
@@ -22,4 +23,9 @@ export function convertFromEnumToUrl(arg: Enums): string {
   } else {
     return roleToUrl[arg]
   }
+}
+
+export function getPageType(pageEnum: PageEnum): 'genre' | 'role' {
+  if (genreTypeChecker(pageEnum)) return 'genre'
+  return 'role'
 }

--- a/src/components/atoms/videoInfo/VideoInfo.tsx
+++ b/src/components/atoms/videoInfo/VideoInfo.tsx
@@ -1,6 +1,4 @@
 import { Typography } from '@mui/material'
-import { ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 
 type VideoInfoProps = {
   label: string
@@ -9,11 +7,9 @@ type VideoInfoProps = {
 
 export function VideoInfo({ label, info }: VideoInfoProps) {
   return (
-    <span>
-      <Typography>
-        <b>{label}: </b>
-        {info}
-      </Typography>
-    </span>
+    <Typography>
+      <b>{label}: </b>
+      {info}
+    </Typography>
   )
 }

--- a/src/components/molecules/videoCard/VideoCard.tsx
+++ b/src/components/molecules/videoCard/VideoCard.tsx
@@ -8,22 +8,26 @@ import { IVideoCard } from '../../../common/interfaces/IVideoCard'
 import {
   convertFromEnumToText,
   convertFromEnumToUrl,
+  getPageType,
 } from '../../../common/utils/utils'
 import { Link } from 'react-router-dom'
 import { VideoInfoWithLink } from '../../atoms/videoInfoWithLink/videoInfoWithLink'
+import { PageEnum } from '../../../common/constants/constants'
 
-type VideoCardProps = Omit<IVideoCard, 'isRecentWork'>
+type VideoCardProps = {
+  video: Omit<IVideoCard, 'isRecentWork'>
+  pageEnum: PageEnum
+}
 
 // TODO: Video needs to take full width of Card
 export function VideoCard({
-  url,
-  title,
-  clientName,
-  roles,
-  genres,
+  video: { url, title, clientName, roles, genres },
+  pageEnum,
 }: VideoCardProps) {
   const mediaCardVideo = useMemo(() => <Video url={url} />, [url])
   const videoTitle = useMemo(() => <VideoTitle title={title} />, [title])
+
+  const pageType = getPageType(pageEnum)
 
   const clientComponent = useMemo(
     () => <VideoInfo label="Client" info={clientName} />,
@@ -31,15 +35,17 @@ export function VideoCard({
   )
 
   const rolesComponent = useMemo(() => {
+    if (pageType === 'role') return null
     return <VideoInfoWithLink label="Roles" linkableInfo={roles} />
-  }, [roles])
+  }, [roles, pageType])
 
   const genresComponent = useMemo(() => {
+    if (pageType === 'genre') return null
     return <VideoInfoWithLink label="Genres" linkableInfo={genres} />
-  }, [genres])
+  }, [genres, pageType])
 
   return (
-    <Card elevation={0} variant='outlined' sx={{width: 1}}>
+    <Card elevation={0} variant="outlined" sx={{ width: 1 }}>
       {mediaCardVideo}
       <CardContent>
         {videoTitle}

--- a/src/components/organisms/videoList/VideoList.tsx
+++ b/src/components/organisms/videoList/VideoList.tsx
@@ -1,15 +1,17 @@
 import { Grid } from '@mui/material'
 import { IVideoCard } from '../../../common/interfaces/IVideoCard'
 import { VideoCard } from '../../molecules/videoCard/VideoCard'
+import { PageEnum } from '../../../common/constants/constants'
 
 type VideoListProps = {
   videos: IVideoCard[]
+  pageEnum: PageEnum
 }
 
-export function VideoList({ videos }: VideoListProps) {
+export function VideoList({ videos, pageEnum }: VideoListProps) {
   const videoComponents = videos.map((iVideo, index) => (
     <Grid item xs={12} md={6} key={`grid-item-video-list-${iVideo.title}`}>
-      <VideoCard {...iVideo} />
+      <VideoCard video={iVideo} pageEnum={pageEnum} />
     </Grid>
   ))
   return (

--- a/src/components/templates/VideoListPage.tsx
+++ b/src/components/templates/VideoListPage.tsx
@@ -24,7 +24,7 @@ export function VideoListPage() {
   return (
     <>
       <PageTitle title={pageEnum} />
-      <VideoList videos={videosForPage} />
+      <VideoList videos={videosForPage} pageEnum={pageEnum} />
     </>
   )
 }


### PR DESCRIPTION
When on a "Roles" page, we don't show the role tag
When on a "Genre" page, we don't show genre tag