### PR TITLE
Fixing FooterLink arrangement and capitalization

### DIFF
--- a/src/components/molecules/footer/FooterLinks.tsx
+++ b/src/components/molecules/footer/FooterLinks.tsx
@@ -13,11 +13,11 @@ export function FooterLinks({ title, items }: FooterLinksProps) {
         display: 'flex',
         flexDirection: 'column',
         color: 'white',
-        marginBottom: '10px',
+        paddingTop: '30px'
       }}
     >
       {title && (
-        <Typography variant="subtitle1" style={{ margin: '5px 0' }}>
+        <Typography variant="subtitle1" sx={{ fontSize: '10px' }}>
           {title}
         </Typography>
       )}
@@ -27,7 +27,7 @@ export function FooterLinks({ title, items }: FooterLinksProps) {
           to={item.link}
           style={{ textDecoration: 'none', color: 'white' }}
         >
-          <Typography variant="subtitle1" style={{ margin: '5px 0' }}>
+          <Typography variant="subtitle1" sx={{ fontSize: '10px'}}>
             {item.label}
           </Typography>
         </Link>

--- a/src/components/molecules/footer/FooterLinks.tsx
+++ b/src/components/molecules/footer/FooterLinks.tsx
@@ -2,11 +2,10 @@ import { Link } from 'react-router-dom';
 import Typography from '@mui/material/Typography';
 
 type FooterLinksProps = {
-  title: string;
   items: { label: string; link: string }[];
 };
 
-export function FooterLinks({ title, items }: FooterLinksProps) {
+export function FooterLinks({ items }: FooterLinksProps) {
   return (
     <div
       style={{
@@ -16,11 +15,11 @@ export function FooterLinks({ title, items }: FooterLinksProps) {
         paddingTop: '30px'
       }}
     >
-      {title && (
+      {/* {title && (
         <Typography variant="subtitle1" sx={{ fontSize: '10px' }}>
           {title}
         </Typography>
-      )}
+      )} */}
       {items.map((item, index) => (
         <Link
           key={index}

--- a/src/components/organisms/Footer/Footer.tsx
+++ b/src/components/organisms/Footer/Footer.tsx
@@ -13,17 +13,16 @@ import { enumMappings } from '../../../common/constants/constants'
 export function Footer() {
   const generateColumnData = (
     enumValues: readonly Genre[] | readonly Role[],
-    title: string,
   ) => {
     const items = enumValues.map(value => ({
       label: enumMappings[value].label,
       link: enumMappings[value].url,
     }))
-    return { title, items }
+    return { items }
   }
 
-  const roleColumnData = generateColumnData(roles, 'ROLE' )
-  const genreColumnData = generateColumnData(genres, 'GENRE' )
+  const roleColumnData = generateColumnData(roles )
+  const genreColumnData = generateColumnData(genres )
 
   const transformedNavLinks = navLinks.map(({ route, label }) => ({
     label,
@@ -46,16 +45,14 @@ export function Footer() {
           marginBottom: '10px',
         }}
       >
-        <FooterLinks title="" items={transformedNavLinks} />
+        <FooterLinks items={transformedNavLinks} />
 
         <FooterLinks
-          title={roleColumnData.title}
           items={roleColumnData.items}
         />
 
 
         <FooterLinks
-          title={genreColumnData.title}
           items={genreColumnData.items}
         />
       </div>

--- a/src/components/organisms/Footer/Footer.tsx
+++ b/src/components/organisms/Footer/Footer.tsx
@@ -14,17 +14,16 @@ export function Footer() {
   const generateColumnData = (
     enumValues: readonly Genre[] | readonly Role[],
     title: string,
-    prefix: string = ''
   ) => {
     const items = enumValues.map(value => ({
-      label: value.replaceAll('_', ' '),
+      label: enumMappings[value].label,
       link: enumMappings[value].url,
     }))
     return { title, items }
   }
 
-  const roleColumnData = generateColumnData(roles, 'ROLE', 'videos?role=')
-  const genreColumnData = generateColumnData(genres, 'GENRE', 'videos?genre=')
+  const roleColumnData = generateColumnData(roles, 'ROLE' )
+  const genreColumnData = generateColumnData(genres, 'GENRE' )
 
   const transformedNavLinks = navLinks.map(({ route, label }) => ({
     label,
@@ -53,6 +52,7 @@ export function Footer() {
           title={roleColumnData.title}
           items={roleColumnData.items}
         />
+
 
         <FooterLinks
           title={genreColumnData.title}


### PR DESCRIPTION
Noticed the `FooterLInks` for ROLE and GENRE weren't coming through captilized. 
Fixed that as well as adjusted the fontSize of them so they arrange more in-line with mockups. 

<img width="411" alt="Screen Shot 2024-02-09 at 11 02 49 AM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/9ad70e12-6f38-4539-bfc3-d80ec195985a">
