### PR TITLE
useNavigate switch on Chips

### DIFF
--- a/src/components/atoms/chipsForEnum/ChipsForEnum.tsx
+++ b/src/components/atoms/chipsForEnum/ChipsForEnum.tsx
@@ -2,13 +2,15 @@ import Chip from '@mui/material/Chip'
 import { Genre, Role } from '../../../common/constants/enums'
 import { enumMappings } from '../../../common/constants/constants'
 import { SxProps, useTheme } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
 
 export function ChipsForEnum({ value }: { value: Genre | Role }): JSX.Element {
   const { label, url } = enumMappings[value]
   const theme = useTheme()
+  const navigate = useNavigate()
 
   const handleClick = () => {
-    window.location.href = url
+    navigate(url)
   }
 
   const chipCssProperties: SxProps = {


### PR DESCRIPTION
`ChipsForEnum` component now utilizes `useNavigate()`.