### PR TITLE
"Recent Work" page title removed. Title prop made optional

### DIFF
--- a/src/components/atoms/pageTitle/PageTitle.tsx
+++ b/src/components/atoms/pageTitle/PageTitle.tsx
@@ -1,7 +1,7 @@
 import { Container, SxProps, Typography } from '@mui/material'
 
 type PageTitleProps = {
-  title: string
+  title?: string
   titleUnderlineColor?: string
   subheaderText?: string
   sx?: SxProps
@@ -28,7 +28,7 @@ export function PageTitle({
   return (
     <Container sx={{ ...sx }} disableGutters={true}>
       <Typography variant="h1" sx={titleUnderline}>
-        {title.toLocaleUpperCase()}
+        {title?.toLocaleUpperCase()}
       </Typography>
       {subheaderText && (
         <Typography variant="body1">{subheaderText}</Typography>

--- a/src/components/organisms/videoList/VideoList.tsx
+++ b/src/components/organisms/videoList/VideoList.tsx
@@ -17,7 +17,6 @@ export function VideoList({ videos, pageType }: VideoListProps) {
   return (
     <>
       <PageTitle
-        title="RECENT WORK"
         sx={{ padding: '32px 16px 16px', fontSize: '1.75rem', fontWeight: '400' }}
       />
       <Grid container spacing={2}>


### PR DESCRIPTION
Previous:
![image](https://github.com/mwkwsd/sensensomething/assets/102488171/2be0c3f4-9181-400c-b92a-2c9276f13de1)

Current:
<img width="421" alt="Screen Shot 2024-03-06 at 5 14 50 PM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/e62c9d74-4bd4-4d5e-bc05-f90b18002738">
