### PR TITLE
show more button and limit videos scrolls

### DIFF
--- a/src/components/atoms/buttons/HireMeButton.tsx
+++ b/src/components/atoms/buttons/HireMeButton.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@mui/material'
+import { Link, useLocation } from 'react-router-dom'
+
+export function HireMeButton() {
+  const location = useLocation()
+  const isHomePage = location.pathname === '/'
+
+  if (isHomePage) {
+    return null
+  }
+
+  return (
+    <Button
+      component={Link}
+      to="/#contact"
+      sx={{
+        color: 'white',
+        margin: '16px auto',
+        display: 'block',
+        position: 'relative',
+        textAlign: 'center',
+        paddingBottom: '1rem',
+      }}
+    >
+      <div
+        style={{
+          borderBottom: '1px solid white',
+          display: 'inline',
+          padding: '0 10px 10px',
+        }}
+      >
+        READY TO HIRE ME?
+      </div>
+    </Button>
+  )
+}

--- a/src/components/atoms/buttons/HireMeButton.tsx
+++ b/src/components/atoms/buttons/HireMeButton.tsx
@@ -1,14 +1,7 @@
 import { Button } from '@mui/material'
-import { Link, useLocation } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 
 export function HireMeButton() {
-  const location = useLocation()
-  const isHomePage = location.pathname === '/'
-
-  if (isHomePage) {
-    return null
-  }
-
   return (
     <Button
       component={Link}

--- a/src/components/atoms/buttons/ShowMoreButton.tsx
+++ b/src/components/atoms/buttons/ShowMoreButton.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@mui/material'
+
+type ShowMoreButtonProps = {
+  onClick: () => void
+}
+
+export function ShowMoreButton({ onClick }: ShowMoreButtonProps) {
+  return (
+    <Button
+      onClick={onClick}
+      sx={{
+        color: 'white',
+        margin: '16px auto',
+        display: 'block',
+        position: 'relative',
+        paddingBottom: '1rem',
+      }}
+    >
+      <div
+        style={{
+          borderBottom: '1px solid white',
+          display: 'inline',
+          padding: '0 10px 10px',
+        }}
+      >
+        KEEP SHOWING MORE
+      </div>
+    </Button>
+  )
+}

--- a/src/components/organisms/videoList/VideoList.tsx
+++ b/src/components/organisms/videoList/VideoList.tsx
@@ -3,6 +3,7 @@ import { IVideoInfo } from '../../../common/interfaces/IVideoInfo'
 import { PageTitle } from '../../atoms/pageTitle/PageTitle'
 import { VideoCard } from '../../molecules/videoCard/VideoCard'
 import { ShowMoreButton } from '../../atoms/buttons/ShowMoreButton'
+import { HireMeButton } from '../../atoms/buttons/HireMeButton'
 import { useState } from 'react'
 
 type VideoListProps = {
@@ -17,12 +18,18 @@ export function VideoList({ videos, pageType }: VideoListProps) {
   )
 
   const handleShowMore = () => {
-    const currentVisibleCount = visibleVideos.length;
-    const nextVisibleVideos = videos.slice(currentVisibleCount, currentVisibleCount + videosPerPage);
-    setVisibleVideos((prevVisibleVideos: IVideoInfo[]) => [...prevVisibleVideos, ...nextVisibleVideos]);
-  };
+    const currentVisibleCount = visibleVideos.length
+    const nextVisibleVideos = videos.slice(
+      currentVisibleCount,
+      currentVisibleCount + videosPerPage
+    )
+    setVisibleVideos((prevVisibleVideos: IVideoInfo[]) => [
+      ...prevVisibleVideos,
+      ...nextVisibleVideos,
+    ])
+  }
 
-  const allVideosDisplayed = visibleVideos.length === videos.length;
+  const allVideosDisplayed = visibleVideos.length === videos.length
 
   const videoComponents = visibleVideos.map((video: IVideoInfo) => (
     <Grid item xs={12} md={6} key={`grid-item-video-list-${video.title}`}>
@@ -43,9 +50,8 @@ export function VideoList({ videos, pageType }: VideoListProps) {
       <Grid container spacing={2}>
         {videoComponents}
       </Grid>
-      {!allVideosDisplayed && (
-        <ShowMoreButton onClick={handleShowMore} />
-      )}
+      {!allVideosDisplayed && <ShowMoreButton onClick={handleShowMore} />}
+      <HireMeButton />
     </>
   )
 }

--- a/src/components/organisms/videoList/VideoList.tsx
+++ b/src/components/organisms/videoList/VideoList.tsx
@@ -2,6 +2,8 @@ import { Grid } from '@mui/material'
 import { IVideoInfo } from '../../../common/interfaces/IVideoInfo'
 import { PageTitle } from '../../atoms/pageTitle/PageTitle'
 import { VideoCard } from '../../molecules/videoCard/VideoCard'
+import { ShowMoreButton } from '../../atoms/buttons/ShowMoreButton'
+import { useState } from 'react'
 
 type VideoListProps = {
   videos: IVideoInfo[]
@@ -9,20 +11,41 @@ type VideoListProps = {
 }
 
 export function VideoList({ videos, pageType }: VideoListProps) {
-  const videoComponents = videos.map(video => (
+  const videosPerPage = 3
+  const [visibleVideos, setVisibleVideos] = useState(
+    videos.slice(0, videosPerPage)
+  )
+
+  const handleShowMore = () => {
+    const currentVisibleCount = visibleVideos.length;
+    const nextVisibleVideos = videos.slice(currentVisibleCount, currentVisibleCount + videosPerPage);
+    setVisibleVideos((prevVisibleVideos: IVideoInfo[]) => [...prevVisibleVideos, ...nextVisibleVideos]);
+  };
+
+  const allVideosDisplayed = visibleVideos.length === videos.length;
+
+  const videoComponents = visibleVideos.map((video: IVideoInfo) => (
     <Grid item xs={12} md={6} key={`grid-item-video-list-${video.title}`}>
       <VideoCard video={video} pageType={pageType} />
     </Grid>
   ))
+  console.log(videoComponents)
   return (
     <>
       <PageTitle
         title="RECENT WORK"
-        sx={{ padding: '32px 16px 16px', fontSize: '1.75rem', fontWeight: '400' }}
+        sx={{
+          padding: '32px 16px 16px',
+          fontSize: '1.75rem',
+          fontWeight: '400',
+        }}
       />
       <Grid container spacing={2}>
         {videoComponents}
       </Grid>
+      {!allVideosDisplayed && (
+        <ShowMoreButton onClick={handleShowMore} />
+      )}
     </>
   )
 }

--- a/src/components/organisms/videoList/VideoList.tsx
+++ b/src/components/organisms/videoList/VideoList.tsx
@@ -5,28 +5,25 @@ import { VideoCard } from '../../molecules/videoCard/VideoCard'
 import { ShowMoreButton } from '../../atoms/buttons/ShowMoreButton'
 import { HireMeButton } from '../../atoms/buttons/HireMeButton'
 import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
 
 type VideoListProps = {
   videos: IVideoInfo[]
   pageType: 'genre' | 'role' | 'recent'
 }
 
+const videosPerPage = 3
+
 export function VideoList({ videos, pageType }: VideoListProps) {
-  const videosPerPage = 3
+  const location = useLocation()
+  const isHomePage = location.pathname === '/'
+
   const [visibleVideos, setVisibleVideos] = useState(
     videos.slice(0, videosPerPage)
   )
 
   const handleShowMore = () => {
-    const currentVisibleCount = visibleVideos.length
-    const nextVisibleVideos = videos.slice(
-      currentVisibleCount,
-      currentVisibleCount + videosPerPage
-    )
-    setVisibleVideos((prevVisibleVideos: IVideoInfo[]) => [
-      ...prevVisibleVideos,
-      ...nextVisibleVideos,
-    ])
+    setVisibleVideos(videos.slice(0, visibleVideos.length + videosPerPage))
   }
 
   const allVideosDisplayed = visibleVideos.length === videos.length
@@ -50,8 +47,8 @@ export function VideoList({ videos, pageType }: VideoListProps) {
       <Grid container spacing={2}>
         {videoComponents}
       </Grid>
+      {!isHomePage && <HireMeButton />}
       {!allVideosDisplayed && <ShowMoreButton onClick={handleShowMore} />}
-      <HireMeButton />
     </>
   )
 }


### PR DESCRIPTION
Limited videos that are displayed on a video lists page start at 3. 
Implemented a `ShowMoreButton` that then shows 3 more. 
The button continues to render until the User hits the end of the current `VideoList`. 

'KEEP SHOWING MORE' button:
<img width="412" alt="Screen Shot 2024-03-08 at 3 41 48 PM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/4c59c51b-fe30-4015-a6b6-a97788fc669e">

Added `READY TO HIRE ME?` button below the 'KEEP SHOWING MORE'. 
Links to Contact component.
Figma calls for 'KEEP SHOWING MORE' to be below the `READY TO HIRE ME?` button, but I think logically the reverse makes more sense from a UI perspective. 
<img width="387" alt="Screen Shot 2024-03-08 at 4 01 01 PM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/157de698-5997-407a-a0e5-b61bb761c1b6">
