### PR TITLE
`ScrollToHashElement` import went missing

### DIFF
--- a/src/components/pages/kurtApp/KurtApp.tsx
+++ b/src/components/pages/kurtApp/KurtApp.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Outlet } from 'react-router-dom'
+import { ScrollToHashElement } from '../../atoms/utilityComponents/ScrollToHashElement'
 import { Footer } from '../../organisms/Footer/Footer'
 import { VideoModal } from '../../organisms/modal/VideoModal'
 import { NavBar } from '../../templates/NavBar'
@@ -9,6 +10,7 @@ export function KurtApp() {
   const footer = useMemo(() => <Footer />, [])
   return (
     <>
+      <ScrollToHashElement />
       {navBar}
       <VideoModal />
       <Outlet />


### PR DESCRIPTION
Seems I messed up rebasing the `navCurrentLocation` PR and unintentionally removed the `ScrollToHashElement` import from `KurtApp.tsx`. 
Double-checked the repo code and it was for sure gone. 
This is me putting it back. 