### PR TITLE
removed Spaceholder from VideoList

### DIFF
--- a/src/components/atoms/pageTitle/PageTitle.tsx
+++ b/src/components/atoms/pageTitle/PageTitle.tsx
@@ -13,24 +13,25 @@ export function PageTitle({
   titleUnderlineColor,
   subheaderText,
   sx,
-  fullWidth
+  fullWidth,
 }: PageTitleProps) {
-  const titleUnderline: SxProps = titleUnderlineColor
-    ? {
-        paddingBottom: '16px',
-        width: fullWidth ? '100%' : '40px',
-        ':after': {
-          border: `1px solid ${titleUnderlineColor}`,
-          display: 'block',
-          content: '""',
-          width: fullWidth ? '100%' : '40px',
-        },
-      }
-    : { paddingBottom: '16px' }
-
   return (
     <Container sx={{ ...sx }} disableGutters={true}>
-      <Typography variant="h1" sx={titleUnderline}>
+      <Typography
+        variant="h1"
+        sx={{
+          paddingBottom: subheaderText ? '16px' : '0', 
+          width: fullWidth ? '100%' : '40px',
+          ':after': {
+            border: titleUnderlineColor
+              ? `1px solid ${titleUnderlineColor}`
+              : 'none',
+            display: 'block',
+            content: '""',
+            width: fullWidth ? '100%' : '40px',
+          },
+        }}
+      >
         {title?.toLocaleUpperCase()}
       </Typography>
       {subheaderText && (

--- a/src/components/organisms/videoList/VideoList.tsx
+++ b/src/components/organisms/videoList/VideoList.tsx
@@ -1,6 +1,5 @@
 import { Grid } from '@mui/material'
 import { IVideoInfo } from '../../../common/interfaces/IVideoInfo'
-import { PageTitle } from '../../atoms/pageTitle/PageTitle'
 import { VideoCard } from '../../molecules/videoCard/VideoCard'
 import { ShowMoreButton } from '../../atoms/buttons/ShowMoreButton'
 import { HireMeButton } from '../../atoms/buttons/HireMeButton'
@@ -34,11 +33,9 @@ export function VideoList({ videos, pageType }: VideoListProps) {
     </Grid>
   ))
   console.log(videoComponents)
+
   return (
     <>
-      <PageTitle
-        sx={{ padding: '32px 16px 16px', fontSize: '1.75rem', fontWeight: '400' }}
-      />
       <Grid container spacing={2}>
         {videoComponents}
       </Grid>


### PR DESCRIPTION
With `subheaderText`:
<img width="417" alt="Screen Shot 2024-03-29 at 3 15 36 PM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/98c6a140-d244-4016-8c99-3c5b9e60f1b4">

Without `subheaderText`:
<img width="446" alt="Screen Shot 2024-03-29 at 3 15 41 PM" src="https://github.com/mwkwsd/sensensomething/assets/102488171/d95b360c-907d-45ed-84f6-6f7c3c4084bf">
