### PR TITLE
Rounded Corners removed from VideoCards

### DIFF
--- a/src/components/molecules/seriesListCard/SeriesListCard.tsx
+++ b/src/components/molecules/seriesListCard/SeriesListCard.tsx
@@ -23,7 +23,7 @@ export function SeriesListCard({ seriesInfo }: SeriesListCardProps) {
   // const videoInfo = getVideoInfoForSeriesDetail(seriesInfo)
 
   return (
-    <Card>
+    <Card sx={{ borderRadius: 0 }} >
       <CardContent>
         <VideoTitle title={name} sx={{ paddingBottom: '0.75rem' }} />
         {shortDescription && (

--- a/src/components/molecules/seriesListCard/SeriesListCard.tsx
+++ b/src/components/molecules/seriesListCard/SeriesListCard.tsx
@@ -23,7 +23,7 @@ export function SeriesListCard({ seriesInfo }: SeriesListCardProps) {
   // const videoInfo = getVideoInfoForSeriesDetail(seriesInfo)
 
   return (
-    <Card sx={{ borderRadius: 0 }} >
+    <Card >
       <CardContent>
         <VideoTitle title={name} sx={{ paddingBottom: '0.75rem' }} />
         {shortDescription && (

--- a/src/components/molecules/videoCard/VideoCard.tsx
+++ b/src/components/molecules/videoCard/VideoCard.tsx
@@ -26,7 +26,7 @@ export function VideoCard({ video, pageType }: VideoCardProps) {
   }, [roles, genres, pageType])
 
   return (
-    <Card sx={{ borderRadius: 0 }} >
+    <Card >
       <CardMedia>
         <PreModalImage videoInfo={video} />
       </CardMedia>

--- a/src/components/molecules/videoCard/VideoCard.tsx
+++ b/src/components/molecules/videoCard/VideoCard.tsx
@@ -26,7 +26,7 @@ export function VideoCard({ video, pageType }: VideoCardProps) {
   }, [roles, genres, pageType])
 
   return (
-    <Card>
+    <Card sx={{ borderRadius: 0 }} >
       <CardMedia>
         <PreModalImage videoInfo={video} />
       </CardMedia>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -102,6 +102,7 @@ const theme = createTheme({
     MuiCard: {
       styleOverrides: {
         root: {
+          borderRadius: '0',
           backgroundColor: '#0C0D0D',
         },
       },


### PR DESCRIPTION
Upper corners no longer rounded on `VideoCards`:

<img width="476" alt="Screenshot 2025-03-14 at 6 30 03 PM" src="https://github.com/user-attachments/assets/d0b2b4d5-5372-426f-9756-5583beab2b5b" />

Explore Series Page:
<img width="452" alt="Screenshot 2025-03-14 at 6 30 57 PM" src="https://github.com/user-attachments/assets/30e440ba-1835-45b9-8a89-211ffb845542" />
