### PR TITLE
Added 'key' prop to VideoList

### DIFF
--- a/src/assets/pages/documentary.ts
+++ b/src/assets/pages/documentary.ts
@@ -3,8 +3,8 @@ import { IVideoListPageInfo } from '../../common/interfaces/IVideoListPageInfo'
 export const documentaryPageInfo: IVideoListPageInfo = {
   pageTitle: 'Documentary',
   videoTitles: [
-    'From Mass to the Mountain',
     'Meet The Pill Bug',
+    'From Mass to the Mountain',
     'Afro Punk Ballet',
     'How To: Go Wicky-Wacky with Bridge',
   ],

--- a/src/assets/pages/documentary.ts
+++ b/src/assets/pages/documentary.ts
@@ -3,8 +3,8 @@ import { IVideoListPageInfo } from '../../common/interfaces/IVideoListPageInfo'
 export const documentaryPageInfo: IVideoListPageInfo = {
   pageTitle: 'Documentary',
   videoTitles: [
-    'Meet The Pill Bug',
     'From Mass to the Mountain',
+    'Meet The Pill Bug',
     'Afro Punk Ballet',
     'How To: Go Wicky-Wacky with Bridge',
   ],

--- a/src/components/templates/VideoListPage.tsx
+++ b/src/components/templates/VideoListPage.tsx
@@ -1,23 +1,23 @@
-import { useMemo } from 'react'
-import { IVideoInfo } from '../../common/interfaces/IVideoInfo'
-import { VideoList } from '../organisms/videoList/VideoList'
-import { PageTitle } from '../atoms/pageTitle/PageTitle'
-import { useLoaderData } from 'react-router-dom'
-import { VideoPageArgs, getVideoInfoForTitle } from '../../common/utils/utils'
 import { useTheme } from '@mui/system'
+import { useMemo } from 'react'
+import { useLoaderData } from 'react-router-dom'
+import { IVideoInfo } from '../../common/interfaces/IVideoInfo'
+import { VideoPageArgs, getVideoInfoForTitle } from '../../common/utils/utils'
+import { PageTitle } from '../atoms/pageTitle/PageTitle'
+import { VideoList } from '../organisms/videoList/VideoList'
 
 /**
  * @returns Page for showing video lists for Roles (Director & Producer, Director of Photography) and Documentary
  */
 export function VideoListPage() {
-  const [videoPageInfo, pageEnum, pageType] = useLoaderData() as VideoPageArgs
+  const [videoPageInfo, pageEnum, pageType] = useLoaderData<VideoPageArgs>()
   const theme = useTheme()
 
   const videosForPage = useMemo(
     () =>
       videoPageInfo.videoTitles
         .map(videoTitle => getVideoInfoForTitle(videoTitle))
-        .filter((video): video is NonNullable<IVideoInfo> => !!video),
+        .filter((video): video is IVideoInfo => !!video),
     [videoPageInfo.videoTitles]
   )
 
@@ -29,9 +29,13 @@ export function VideoListPage() {
         title={videoPageInfo.pageTitle}
         titleUnderlineColor={titleUnderlineColor}
         subheaderText={videoPageInfo.subheaderText}
-        sx={{ padding: '16px 16px 24px' }}
+        sx={{ padding: '1rem 1rem 1.5rem' }}
       />
-      <VideoList videos={videosForPage} pageType={pageType} />
+      <VideoList
+        key={`video-list-${pageType}`}
+        videos={videosForPage}
+        pageType={pageType}
+      />
     </>
   )
 }


### PR DESCRIPTION
React has some built in memoization. When we naviate between routes, although we have different videos, React does its best to rerender as little as possible. 

In the memoization process, React stores the components by the `key` prop. If the key prop changes, then React knows to rerender that component and all children. 

I've added the `key` prop to the `<VideoListPage>` render.  Now, when switching pages, the key changes and React rerenders the component.

Closes #212 