### PR TITLE
Extend About Page images to screen width

### DIFF
--- a/src/components/atoms/pageTitle/PageTitle.tsx
+++ b/src/components/atoms/pageTitle/PageTitle.tsx
@@ -17,7 +17,6 @@ export function PageTitle({
 }: PageTitleProps) {
   const titleUnderline: SxProps = {
     paddingBottom: '0.5rem',
-    marginBottom: '1rem',
     position: 'relative',
     ':after': {
       border: titleUnderlineColor

--- a/src/components/atoms/pageTitle/PageTitle.tsx
+++ b/src/components/atoms/pageTitle/PageTitle.tsx
@@ -37,7 +37,9 @@ export function PageTitle({
         {title}
       </Typography>
       {subheaderText && (
-        <Typography variant="body1">{subheaderText}</Typography>
+        <Typography variant="body1" sx={{ paddingTop: '1rem' }}>
+          {subheaderText}
+        </Typography>
       )}
     </Container>
   )

--- a/src/components/molecules/About/AboutPage.tsx
+++ b/src/components/molecules/About/AboutPage.tsx
@@ -4,26 +4,31 @@ import { PageTitle } from '../../atoms/pageTitle/PageTitle'
 import { Contact } from '../../templates/Contact'
 
 export function AboutPage() {
-  const theme = useTheme()
+  const {
+    palette: {
+      series: { main: underlineColor },
+    },
+  } = useTheme()
 
   return (
     <>
       <PageTitle
         title="About"
-        titleUnderlineColor={theme.palette.series.main}
+        titleUnderlineColor={underlineColor}
         fullWidth={true}
       />
       {Kurt.map((item, index) => (
-        <Box key={index}>
+        <Box key={index} sx={{ paddingTop: '1rem' }}>
           <Typography variant="body1">{item.description}</Typography>
-          <img
+          <Box
+            component="img"
             src={item.photo.path}
             alt={item.photo.alt}
-            style={{
-              height: '100%',
-              width: '100%',
-              paddingTop: '15px',
-              paddingBottom: '15px',
+            sx={{
+              width: '100vw',
+              overflow: 'auto',
+              paddingY: '0.875rem',
+              marginLeft: '-1rem',
             }}
           />
         </Box>

--- a/src/components/templates/About.tsx
+++ b/src/components/templates/About.tsx
@@ -2,13 +2,16 @@ import { Card, useTheme } from '@mui/material'
 import { AboutPage } from '../molecules/About/AboutPage'
 
 export function About() {
-  const theme = useTheme()
+  const {
+    palette: {
+      background: { default: backgroundColor },
+    },
+  } = useTheme()
 
   return (
     <Card
       elevation={0}
-      variant="outlined"
-      sx={{ margin: 2, backgroundColor: theme.palette.background.default }}
+      sx={{ padding: '1rem', backgroundColor: backgroundColor }}
     >
       <AboutPage />
     </Card>


### PR DESCRIPTION
Addresses #216 

Run App
Go to About Page
See that images are full width of screen.