### PR TITLE
48px above Recent Work Header on Home Page

### DIFF
--- a/src/components/templates/Home.tsx
+++ b/src/components/templates/Home.tsx
@@ -13,7 +13,7 @@ export function Home() {
   return (
     <>
       <LandingPageLinks pages={[...recentWorkPageInfo.orderedPages]} />
-      <Typography variant="h2" sx={{ margin: '32px 0px 16px 16px' }}>Recent Work</Typography>
+      <Typography variant="h2" sx={{ margin: '48px 0px 16px 16px' }}>Recent Work</Typography>
       <VideoList videos={videos} pageType="recent" />
       <Contact />
     </>


### PR DESCRIPTION
Closes #221 

<img width="428" alt="Screenshot 2025-03-26 at 4 00 01 PM" src="https://github.com/user-attachments/assets/8577ea47-be22-4cc8-b4c0-981f515e734c" />
