### PR TITLE
TextInput underline set to 1px

### DIFF
--- a/src/components/atoms/formInput/TextInput.tsx
+++ b/src/components/atoms/formInput/TextInput.tsx
@@ -18,6 +18,12 @@ export function TextInput({ fieldName, label, ...rest }: TextInputProps) {
         display: 'block',
         width: '100%',
       },
+      '::after': {
+      content: '""',
+      borderBottom: `1px solid ${theme.palette.email.main}`, // Ensures it stays the same on focus
+      display: 'block',
+      width: '100%',
+      },
       '& input': {
         color: 'white',
         fontWeight: 400,

--- a/src/components/atoms/formInput/TextInput.tsx
+++ b/src/components/atoms/formInput/TextInput.tsx
@@ -14,15 +14,9 @@ export function TextInput({ fieldName, label, ...rest }: TextInputProps) {
       color: '#FFFFFF',
       '::before': {
         content: '""',
-        border: `1px solid ${theme.palette.email.main}`,
+        border: `0.5px solid ${theme.palette.email.main}`,
         display: 'block',
         width: '100%',
-      },
-      '::after': {
-      content: '""',
-      borderBottom: `1px solid ${theme.palette.email.main}`, // Ensures it stays the same on focus
-      display: 'block',
-      width: '100%',
       },
       '& input': {
         color: 'white',


### PR DESCRIPTION
Closes #222 

Browser Inspector:
<img width="378" alt="Screenshot 2025-03-26 at 4 30 35 PM" src="https://github.com/user-attachments/assets/6fc84319-fdba-460c-8205-08af7df1e839" />

`::after` Code (underline):
<img width="461" alt="Screenshot 2025-03-26 at 4 31 26 PM" src="https://github.com/user-attachments/assets/eec446d3-13c0-450c-a455-5bd15095625a" />

Button styling:
<img width="319" alt="Screenshot 2025-03-26 at 4 31 59 PM" src="https://github.com/user-attachments/assets/ebf27afe-1eb1-4028-8809-1cd17444030a" />

Screenshot:
I'm having a hard time telling, but the TextInput underlines look "heavier" than the button outline still
<img width="415" alt="Screenshot 2025-03-26 at 4 33 38 PM" src="https://github.com/user-attachments/assets/b78b0205-0578-4b12-9209-27c91549177a" />
