### PR TITLE
email validation and remove ability to resubmit empty field

### DIFF
--- a/src/components/molecules/contactForm/ContactForm.tsx
+++ b/src/components/molecules/contactForm/ContactForm.tsx
@@ -49,9 +49,9 @@ export function ContactForm() {
   const sendEmail = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
+    const email_regex = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g
     const currentForm = form.current
 
-    // TODO: enValid package
     if (
       !currentForm ||
       !process.env.REACT_APP_EMAIL_TEMPLATE_ID ||
@@ -59,8 +59,16 @@ export function ContactForm() {
     ) {
       setFormError(true)
       return
-    } // don't love this, but otherwise my sendForm() errors
+    }
     if (allFieldsFilledIn) {
+      if (!fieldStates["email_address"].match(email_regex)) {
+        setFieldErrors(currentFieldErrors => ({
+          ...currentFieldErrors,
+          "email_address": 'not_email',
+        }))
+        return
+      }
+
       emailjs
         .sendForm(
           "default_service",
@@ -71,6 +79,12 @@ export function ContactForm() {
         .then(
           () => {
             setFormSubmitted(true)
+            Object.entries(fieldStates).forEach(([key, value]) => {
+              setFieldStates(currentFieldStates => ({
+                ...currentFieldStates,
+                [key]: '',
+              }))
+            })
           },
           error => {
             console.log(error)
@@ -84,6 +98,13 @@ export function ContactForm() {
           [key]: value === '' ? 'error' : '',
         }))
       })
+
+      if (!fieldStates["email_address"].match(email_regex)) {
+        setFieldErrors(currentFieldErrors => ({
+          ...currentFieldErrors,
+          "email_address": 'not_email',
+        }))
+      }
     }
   }
 
@@ -131,6 +152,10 @@ export function ContactForm() {
               />
               {fieldErrors[i] === 'error' && (
                 <FieldError message="Please fill out this field." />
+              )}
+              {/* This will always display on the email field because we are setting not_email second */}
+              {fieldErrors[i] === 'not_email' && (
+                <FieldError message="Please use a valid email." />
               )}
             </Grid2>
           ))}


### PR DESCRIPTION
closes #121 

Made some decisions here:
1. Did not add react-hook-form for better field/form handling and built in validation because for just this form, it's about the same amount of effort to make the validation myself vs install and hook up react-hook-form. We might decide we want it later.
2. Did not make the email validation a method because it's only used twice, but we could pretty easily do that if we wanted.

Resetting the `allFieldsFilledIn` value was the trick here, because it allowed the form to be resubmitted after the first submit because it's relying on the `fieldStates` changing. The form might reset, but the fieldStates stayed with previous values, so it didn't do what we expected. I'm sure there's a better way here, but oh well.