### PR TITLE
Started on Gear Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
 import { ModalProvider } from './components/organisms/modal/ModalProvider'
 import { KurtApp } from './components/pages/kurtApp/KurtApp'
 import { About } from './components/templates/About'
+import { Gear } from './components/templates/Gear'
 import { ErrorBoundary } from './components/templates/ErrorBoundary'
 import { Home } from './components/templates/Home'
 import { SeriesDetailPage } from './components/templates/SeriesDetailPage'
@@ -36,6 +37,10 @@ const router = createBrowserRouter([
       {
         path: '/about',
         element: <About />,
+      },
+      {
+        path: '/gear',
+        element: <Gear />,
       },
       {
         element: <Home />,

--- a/src/assets/gear/gearList.ts
+++ b/src/assets/gear/gearList.ts
@@ -1,0 +1,14 @@
+export const gearList = [
+  {
+    category: 'Cameras',
+    items: ['Sony FX6', 'Sony FX3', 'Sony FS7', 'RED Komodo'],
+  },
+  {
+    category: 'Lenses',
+    items: ['Angenieux EZ 1', 'Angenieux EZ 2', 'Sony G Masters'],
+  },
+  {
+    category: 'Lights',
+    items: ['IntellyTech LiteCloth 2.0 LC-160 RGB (2)'],
+  },
+] as const

--- a/src/common/constants/enums.ts
+++ b/src/common/constants/enums.ts
@@ -14,4 +14,5 @@ export const navLinks = [
   { route: '/#recent-work', label: 'Recent Work' },
   { route: '/about', label: 'About' },
   { route: '/#contact', label: 'Contact' },
+  { route: '/gear', label: 'Gear'}
 ] as const

--- a/src/common/constants/enums.ts
+++ b/src/common/constants/enums.ts
@@ -14,5 +14,4 @@ export const navLinks = [
   { route: '/#recent-work', label: 'Recent Work' },
   { route: '/about', label: 'About' },
   { route: '/#contact', label: 'Contact' },
-  { route: '/gear', label: 'Gear'}
 ] as const

--- a/src/components/molecules/Gear/GearPage.tsx
+++ b/src/components/molecules/Gear/GearPage.tsx
@@ -30,6 +30,17 @@ export function GearPage() {
           </Box>
         ))}
       </Box>
+
+      <Typography
+        variant="body1"
+        sx={{ textAlign: 'center', marginTop: '1rem', paddingX: '1rem' }}
+      >
+        A list of camera support options, grip gear, etc. is available upon
+        request.
+        <br />
+        Please contact me with any questions and to discuss rates.
+      </Typography>
+
       <Contact />
     </>
   )

--- a/src/components/molecules/Gear/GearPage.tsx
+++ b/src/components/molecules/Gear/GearPage.tsx
@@ -1,0 +1,36 @@
+import { Box, Typography } from '@mui/material'
+import { PageTitle } from '../../atoms/pageTitle/PageTitle'
+import { Contact } from '../../templates/Contact'
+import { gearList } from '../../../assets/gear/gearList'
+
+export function GearPage() {
+  return (
+    <>
+      <PageTitle
+        title="Gear / Gear for Rent"
+        fullWidth={true}
+        sx={{ padding: '1rem 1rem' }}
+      />
+      <Box component="ul" sx={{ paddingX: '1rem' }}>
+        {gearList.map(section => (
+          <Box key={section.category} sx={{ marginBottom: '1.5rem' }}>
+            <Typography variant="h2" sx={{ marginBottom: '0.5rem' }}>
+              {section.category}
+            </Typography>
+            <Box
+              component="ul"
+              sx={{ paddingLeft: '1.5rem', listStyle: 'none' }}
+            >
+              {section.items.map((item, itemIndex) => (
+                <Typography key={itemIndex} component="li" variant="h3">
+                  {item}
+                </Typography>
+              ))}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+      <Contact />
+    </>
+  )
+}

--- a/src/components/molecules/Gear/GearPage.tsx
+++ b/src/components/molecules/Gear/GearPage.tsx
@@ -1,13 +1,20 @@
-import { Box, Typography } from '@mui/material'
+import { Box, Typography, useTheme } from '@mui/material'
 import { PageTitle } from '../../atoms/pageTitle/PageTitle'
 import { Contact } from '../../templates/Contact'
 import { gearList } from '../../../assets/gear/gearList'
 
 export function GearPage() {
+  const {
+      palette: {
+        series: { main: underlineColor },
+      },
+    } = useTheme()
+
   return (
     <>
       <PageTitle
         title="Gear / Gear for Rent"
+        titleUnderlineColor={underlineColor}
         fullWidth={true}
         sx={{ padding: '1rem 1rem' }}
       />
@@ -33,7 +40,7 @@ export function GearPage() {
 
       <Typography
         variant="body1"
-        sx={{ textAlign: 'center', marginTop: '1rem', paddingX: '1rem' }}
+        sx={{ textAlign: 'center', marginTop: '1rem', paddingX: '1rem', paddingBottom: '2rem' }}
       >
         A list of camera support options, grip gear, etc. is available upon
         request.

--- a/src/components/molecules/NavList.tsx
+++ b/src/components/molecules/NavList.tsx
@@ -19,14 +19,16 @@ export function NavList({ onClose }: { onClose: () => void }) {
 
   const firstNavLinks = useMemo(
     () =>
-      navLinks.map(item => (
-        <NavLink
-          key={`nav-link-${item.label}`}
-          navLink={item}
-          isSelected={location.pathname === item.route}
-          onClose={onClose}
-        />
-      )),
+      navLinks
+        .filter(item => item.route !== '/gear') 
+        .map(item => (
+          <NavLink
+            key={`nav-link-${item.label}`}
+            navLink={item}
+            isSelected={location.pathname === item.route}
+            onClose={onClose}
+          />
+        )),
     [location.pathname, onClose]
   )
 

--- a/src/components/templates/Gear.tsx
+++ b/src/components/templates/Gear.tsx
@@ -1,0 +1,19 @@
+import { Card, useTheme } from '@mui/material'
+import { GearPage } from '../molecules/Gear/GearPage'
+
+export function Gear() {
+  const {
+    palette: {
+      background: { default: backgroundColor },
+    },
+  } = useTheme()
+
+  return (
+    <Card
+      elevation={0}
+      sx={{ backgroundColor: backgroundColor }}
+    >
+      <GearPage />
+    </Card>
+  )
+}


### PR DESCRIPTION
Closes #239 

Started building out `GearPage.tsx`. 
We can adjust how we get to this page from here, but currently, the endpoint of `/gear` work,s and "Gear" is in the hamburger menu. 

<img width="429" alt="Screenshot 2025-04-10 at 3 03 03 PM" src="https://github.com/user-attachments/assets/a3e97fd3-a917-452d-aa9e-7022331e2208" />
